### PR TITLE
[chore] chore : ec2메모리 부족으로 인해 deploy안되는 오류 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,17 +1,20 @@
-FROM  eclipse-temurin:21-jdk
-
-WORKDIR  /app
+# build stage
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /app
 
 COPY gradlew .
 COPY gradle gradle
 COPY build.gradle settings.gradle ./
-
 RUN chmod +x gradlew
 
 COPY src src
-
 RUN ./gradlew bootJar --no-daemon
 
-EXPOSE 8080
+# runtime stage (JRE사용)
+FROM eclipse-temurin:21-jre
+WORKDIR /app
 
-CMD ["sh", "-c", "java -jar build/libs/*.jar"]
+COPY --from=build /app/build/libs/*.jar /app/app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
ec2 메모리 부족으로 깃허브액션이 오류나서 도커 실행시 메모리 정리를 해주는 명령어 추가하고, dockerfile도 jdk말고 더 가벼운 jre를 사용하도록 변경