### PR TITLE
[be]: corsConfigurationsSource에 ec2 배포 주소 추가

### DIFF
--- a/backend/src/main/java/com/example/qnaboard/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/qnaboard/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000","http://3.35.209.31"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("Authorization", "Content-Type"));


### PR DESCRIPTION
현재 cors설정에 로컬 주소만 허용되어있어서 ec2 주소도 추가하였습니다