### PR TITLE
[be]fix: 특정 유저가 신고한 글이 숨김처리 해제 되었을 때 다시 신고가 안되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/example/qnaboard/repository/report/ReportRepository.java
+++ b/backend/src/main/java/com/example/qnaboard/repository/report/ReportRepository.java
@@ -11,5 +11,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
                                                         Long targetId);
 
     void deleteByTargetId(Long targetId);
+    void deleteByTargetTypeAndTargetId(ReportTargetType targetType, Long targetId);
     long countByTargetTypeAndTargetId(ReportTargetType targetType, Long targetId);
 }

--- a/backend/src/main/java/com/example/qnaboard/service/answer/AnswerServiceImpl.java
+++ b/backend/src/main/java/com/example/qnaboard/service/answer/AnswerServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.qnaboard.service.answer;
 import com.example.qnaboard.domain.answer.Answer;
 import com.example.qnaboard.domain.answer.AnswerVote;
 import com.example.qnaboard.domain.question.Question;
+import com.example.qnaboard.domain.report.ReportTargetType;
 import com.example.qnaboard.domain.user.User;
 import com.example.qnaboard.dto.answer.AnswerCreateRequest;
 import com.example.qnaboard.dto.answer.AnswerResponseDto;
@@ -106,7 +107,7 @@ public class AnswerServiceImpl implements AnswerService {
         userPointService.cancelRewardForAnswer(writerId);
         userPointService.cancelRewardForSelectedAnswer(writerId);
         answerRepository.delete(answer);
-        reportRepository.deleteByTargetId(answerId);
+        reportRepository.deleteByTargetTypeAndTargetId(ReportTargetType.ANSWER,answerId);
     }
 
     @Override

--- a/backend/src/main/java/com/example/qnaboard/service/comment/CommentService.java
+++ b/backend/src/main/java/com/example/qnaboard/service/comment/CommentService.java
@@ -1,6 +1,7 @@
 package com.example.qnaboard.service.comment;
 
 import com.example.qnaboard.domain.comment.Comment;
+import com.example.qnaboard.domain.report.ReportTargetType;
 import com.example.qnaboard.domain.user.User;
 import com.example.qnaboard.dto.comment.request.CommentCreateRequest;
 import com.example.qnaboard.dto.comment.request.CommentUpdateRequest;
@@ -153,7 +154,7 @@ public class CommentService {
         Long writerId = comment.getUser().getId();
         userPointService.cancelRewardForComment(writerId);
         commentRepository.delete(comment);
-        reportRepository.deleteByTargetId(commentId);
+        reportRepository.deleteByTargetTypeAndTargetId(ReportTargetType.COMMENT,commentId);
     }
 
     /* ================= 공통 로직 ================= */

--- a/backend/src/main/java/com/example/qnaboard/service/question/QuestionService.java
+++ b/backend/src/main/java/com/example/qnaboard/service/question/QuestionService.java
@@ -2,6 +2,7 @@ package com.example.qnaboard.service.question;
 
 import com.example.qnaboard.domain.question.Question;
 import com.example.qnaboard.domain.question.QuestionCategory;
+import com.example.qnaboard.domain.report.ReportTargetType;
 import com.example.qnaboard.domain.user.User;
 import com.example.qnaboard.dto.question.request.QuestionCreateRequest;
 import com.example.qnaboard.dto.question.request.QuestionUpdateRequest;
@@ -119,7 +120,7 @@ public class QuestionService {
         Long writerId = question.getUser().getId();
         userPointService.cancelRewardForQuestion(writerId);
         questionRepository.delete(question);
-        reportRepository.deleteByTargetId(questionId);
+        reportRepository.deleteByTargetTypeAndTargetId(ReportTargetType.QUESTION,questionId);
     }
 
     /**

--- a/backend/src/main/java/com/example/qnaboard/service/report/AdminReportService.java
+++ b/backend/src/main/java/com/example/qnaboard/service/report/AdminReportService.java
@@ -10,6 +10,7 @@ import com.example.qnaboard.exception.common.BusinessException;
 import com.example.qnaboard.repository.answer.AnswerRepository;
 import com.example.qnaboard.repository.comment.CommentRepository;
 import com.example.qnaboard.repository.question.QuestionRepository;
+import com.example.qnaboard.repository.report.ReportRepository;
 import com.example.qnaboard.service.answer.AnswerServiceImpl;
 import com.example.qnaboard.service.comment.CommentService;
 import com.example.qnaboard.service.question.QuestionService;
@@ -26,6 +27,7 @@ public class AdminReportService {
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
     private final CommentRepository commentRepository;
+    private final ReportRepository reportRepository;
 
     private final QuestionService questionService;
     private final AnswerServiceImpl answerService;
@@ -57,15 +59,24 @@ public class AdminReportService {
     @Transactional
     public void restore(ReportTargetType type, Long id) {
         switch (type) {
-            case QUESTION -> questionRepository.findById(id)
-                    .orElseThrow(() -> new BusinessException(QuestionErrorCode.QUESTION_NOT_FOUND))
-                    .unhide();
-            case ANSWER -> answerRepository.findById(id)
-                    .orElseThrow(() -> new BusinessException(AnswerErrorCode.ANSWER_NOT_FOUND))
-                    .unhide();
-            case COMMENT -> commentRepository.findById(id)
-                    .orElseThrow(() -> new BusinessException(CommentErrorCode.COMMENT_NOT_FOUND))
-                    .unhide();
+            case QUESTION -> {
+                questionRepository.findById(id)
+                        .orElseThrow(() -> new BusinessException(QuestionErrorCode.QUESTION_NOT_FOUND))
+                        .unhide();
+                reportRepository.deleteByTargetTypeAndTargetId(ReportTargetType.QUESTION,id);
+            }
+            case ANSWER -> {
+                answerRepository.findById(id)
+                        .orElseThrow(() -> new BusinessException(AnswerErrorCode.ANSWER_NOT_FOUND))
+                        .unhide();
+                reportRepository.deleteByTargetTypeAndTargetId(ReportTargetType.ANSWER,id);
+            }
+            case COMMENT -> {
+                commentRepository.findById(id)
+                        .orElseThrow(() -> new BusinessException(CommentErrorCode.COMMENT_NOT_FOUND))
+                        .unhide();
+                reportRepository.deleteByTargetTypeAndTargetId(ReportTargetType.COMMENT,id);
+            }
         }
     }
 }


### PR DESCRIPTION
신고후 숨김처리 해제를 했을 시 해당 글에 대한 신고 report를 전부 삭제해서 중복신고 처리로 되지 않게 수정